### PR TITLE
Enhance hero animations and project styling

### DIFF
--- a/src/components/3d/Globe.tsx
+++ b/src/components/3d/Globe.tsx
@@ -14,6 +14,10 @@ export default function Globe() {
     const geometry = new THREE.BufferGeometry();
     const positions = [];
     const colors = [];
+
+    const style = getComputedStyle(document.documentElement);
+    const primary = new THREE.Color(`hsl(${style.getPropertyValue('--primary')})`);
+    const accent = new THREE.Color(`hsl(${style.getPropertyValue('--accent')})`);
     const color = new THREE.Color();
     
     for (let i = 0; i < 2000; i++) {
@@ -28,7 +32,7 @@ export default function Globe() {
       );
       
       // Random color between primary and accent
-      color.setHSL(0.6 + Math.random() * 0.2, 0.8, 0.6);
+      color.copy(primary).lerp(accent, Math.random());
       colors.push(color.r, color.g, color.b);
     }
     
@@ -40,10 +44,16 @@ export default function Globe() {
   
   useFrame(({ clock }) => {
     if (!globeRef.current || !pointsRef.current) return;
-    
+
     // Rotate the globe
     globeRef.current.rotation.y = clock.getElapsedTime() * 0.1;
     pointsRef.current.rotation.y = clock.getElapsedTime() * 0.1;
+
+    const material = pointsRef.current.material as THREE.PointsMaterial;
+    const hsl = { h: 0, s: 0, l: 0 } as THREE.HSL;
+    material.color.getHSL(hsl);
+    hsl.h = (hsl.h + 0.0005) % 1;
+    material.color.setHSL(hsl.h, hsl.s, hsl.l);
   });
   
   return (

--- a/src/components/dashboard/LiveTickers.tsx
+++ b/src/components/dashboard/LiveTickers.tsx
@@ -32,7 +32,7 @@ export default function LiveTickers() {
         <div className="flex items-center space-x-8 whitespace-nowrap px-4">
           {tickers.map((ticker) => (
             <div key={ticker.symbol} className="flex items-center space-x-2">
-              <span className="font-medium">{ticker.symbol}:</span>
+              <span className="font-medium text-accent">{ticker.symbol}:</span>
               <span>${ticker.price.toLocaleString()}</span>
               <span
                 className={cn(
@@ -59,13 +59,13 @@ export default function LiveTickers() {
           <div className="flex items-center space-x-2">
             <GitCommit className="h-4 w-4" />
             <span>Latest Commit:</span>
-            <span className="text-primary">{lastCommit}</span>
+            <span className="text-accent">{lastCommit}</span>
           </div>
 
           <div className="flex items-center space-x-2">
             <Activity className="h-4 w-4" />
             <span>Uptime:</span>
-            <span className="text-primary">{uptime}</span>
+            <span className="text-accent">{uptime}</span>
           </div>
         </div>
       </div>

--- a/src/components/dashboard/TechNewsFeed.tsx
+++ b/src/components/dashboard/TechNewsFeed.tsx
@@ -159,7 +159,7 @@ const TechNewsFeed: React.FC<TechNewsFeedProps> = ({ className = '' }) => {
 
   if (loading) {
     return (
-      <div className={`bg-gray-900 border border-gray-700 rounded-lg p-6 ${className}`}>
+      <div className={`bg-gray-900 border border-accent rounded-lg p-6 ${className}`}>
         <h3 className="text-lg font-semibold text-white mb-4">Tech News</h3>
         <div className="space-y-4">
           {[...Array(3)].map((_, i) => (
@@ -175,7 +175,7 @@ const TechNewsFeed: React.FC<TechNewsFeedProps> = ({ className = '' }) => {
 
   if (error) {
     return (
-      <div className={`bg-gray-900 border border-gray-700 rounded-lg p-6 ${className}`}>
+      <div className={`bg-gray-900 border border-accent rounded-lg p-6 ${className}`}>
         <h3 className="text-lg font-semibold text-white mb-4">Tech News</h3>
         <div className="text-red-400 text-sm">{error}</div>
       </div>
@@ -183,7 +183,7 @@ const TechNewsFeed: React.FC<TechNewsFeedProps> = ({ className = '' }) => {
   }
 
   return (
-    <div className={`bg-gray-900 border border-gray-700 rounded-lg p-6 ${className}`}>
+    <div className={`bg-gray-900 border border-accent rounded-lg p-6 ${className}`}>
       <h3 className="text-lg font-semibold text-white mb-4">Tech News</h3>
       <div className="overflow-hidden whitespace-nowrap">
         <div className="flex gap-8 animate-marquee items-center">
@@ -193,7 +193,7 @@ const TechNewsFeed: React.FC<TechNewsFeedProps> = ({ className = '' }) => {
                 href={item.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-sm text-gray-300 hover:text-white"
+                className="text-sm text-accent hover:text-white"
               >
                 {item.title}
               </a>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -66,10 +66,10 @@ export default function Hero() {
       <div className="container mx-auto px-4 relative z-10">
         <div className="min-h-screen flex flex-col items-center justify-center text-center">
           {/* Main content */}
-          <div className="space-y-8 max-w-4xl backdrop-blur-sm bg-background/30 p-8 rounded-2xl">
+          <div className="space-y-8 max-w-4xl backdrop-blur-sm bg-background/30 p-8 rounded-2xl tilt-card">
             {/* Avatar/Headshot with enhanced styling */}
             <div className="relative inline-block group">
-              <div className="absolute inset-0 bg-gradient-to-r from-primary to-accent rounded-full blur-xl opacity-50 group-hover:opacity-75 transition-opacity"></div>
+            <div className="absolute inset-0 bg-gradient-to-r from-primary to-accent rounded-full blur-xl opacity-50 group-hover:opacity-75 transition-opacity animated-hue"></div>
               <div className="relative w-32 h-32 md:w-40 md:h-40">
                 <div className="w-full h-full bg-gradient-to-r from-primary to-accent rounded-full p-1">
                   <div className="w-full h-full bg-background rounded-full flex items-center justify-center overflow-hidden">
@@ -111,7 +111,7 @@ export default function Hero() {
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
               <Button
                 size="lg"
-                className="w-full sm:w-auto bg-gradient-to-r from-primary to-accent hover:opacity-90 transition-opacity"
+                className="w-full sm:w-auto bg-gradient-to-r from-primary to-accent hover:opacity-90 transition-opacity hover:scale-105"
               >
                 <a href="#contact" className="flex items-center">
                   Contact Me
@@ -120,7 +120,7 @@ export default function Hero() {
               <Button
                 variant="outline"
                 size="lg"
-                className="w-full sm:w-auto border-primary/20 hover:border-primary/40"
+                className="w-full sm:w-auto border-primary/20 hover:border-primary/40 hover:scale-105"
               >
                 <a
                   href="#"
@@ -135,7 +135,7 @@ export default function Hero() {
               <Button
                 variant="outline"
                 size="lg"
-                className="w-full sm:w-auto border-primary/20 hover:border-primary/40"
+                className="w-full sm:w-auto border-primary/20 hover:border-primary/40 hover:scale-105"
               >
                 <a
                   href="https://github.com/ant3869"

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -119,6 +119,23 @@ const autoProjects = projects.filter((p) => p.type === 'auto');
 const arduinoProjects = projects.filter((p) => p.type === 'arduino');
 const otherProjects = projects.filter((p) => p.type === 'other');
 
+function getCategoryBorder(type: string) {
+  switch (type) {
+    case 'featured':
+      return 'border-yellow-500';
+    case 'prop':
+      return 'border-green-500';
+    case 'ui':
+      return 'border-blue-500';
+    case 'auto':
+      return 'border-purple-500';
+    case 'arduino':
+      return 'border-teal-500';
+    default:
+      return 'border-primary/10';
+  }
+}
+
 export default function Projects() {
   return (
     <section id="projects" className="py-20 bg-muted/20">
@@ -142,7 +159,7 @@ export default function Projects() {
             {featuredProjects.map((project) => (
               <Card
                 key={project.id}
-                className="overflow-hidden border-primary/10 shadow-lg"
+                className={`overflow-hidden border-2 ${getCategoryBorder(project.type)} shadow-lg`}
               >
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div className="p-6 md:p-8 flex flex-col">
@@ -213,7 +230,7 @@ export default function Projects() {
               {propProjects.map((project) => (
                 <Card
                   key={project.id}
-                  className="overflow-hidden card-hover border-primary/10"
+                  className={`overflow-hidden card-hover border-2 ${getCategoryBorder(project.type)}`}
                 >
                   <AspectRatio ratio={16 / 9} className="bg-muted">
                     <img
@@ -280,7 +297,7 @@ export default function Projects() {
             {uiProjects.map((project) => (
               <Card
                 key={project.id}
-                className="overflow-hidden border-primary/10 shadow-lg"
+                className={`overflow-hidden border-2 ${getCategoryBorder(project.type)} shadow-lg`}
               >
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div className="p-6 md:p-8 flex flex-col">
@@ -350,7 +367,7 @@ export default function Projects() {
             {autoProjects.map((project) => (
               <Card
                 key={project.id}
-                className="overflow-hidden border-primary/10 shadow-lg"
+                className={`overflow-hidden border-2 ${getCategoryBorder(project.type)} shadow-lg`}
               >
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div className="p-6 md:p-8 flex flex-col">
@@ -420,7 +437,7 @@ export default function Projects() {
             {arduinoProjects.map((project) => (
               <Card
                 key={project.id}
-                className="overflow-hidden border-primary/10 shadow-lg"
+                className={`overflow-hidden border-2 ${getCategoryBorder(project.type)} shadow-lg`}
               >
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div className="p-6 md:p-8 flex flex-col">
@@ -490,7 +507,7 @@ export default function Projects() {
             {otherProjects.map((project) => (
               <Card
                 key={project.id}
-                className="overflow-hidden border-primary/10 shadow-lg"
+                className={`overflow-hidden border-2 ${getCategoryBorder(project.type)} shadow-lg`}
               >
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div className="p-6 md:p-8 flex flex-col">

--- a/src/index.css
+++ b/src/index.css
@@ -65,6 +65,7 @@
 @layer components {
   .gradient-heading {
     @apply bg-gradient-to-r from-primary via-accent to-secondary bg-clip-text text-transparent animate-gradient;
+    text-shadow: 0 2px 4px hsl(var(--accent) / 0.3);
   }
   
   .section-heading {
@@ -95,6 +96,13 @@
     font-family: 'JetBrains Mono', monospace;
     @apply p-4 rounded-md bg-muted/50 text-sm border overflow-x-auto;
   }
+
+  .tilt-card {
+    @apply transition-transform duration-300 transform-gpu;
+  }
+  .tilt-card:hover {
+    transform: rotateX(6deg) rotateY(-6deg);
+  }
   
   @keyframes marquee {
     0% {
@@ -123,10 +131,23 @@
   }
 }
 
+@keyframes hue-rotate {
+  from {
+    filter: hue-rotate(0deg);
+  }
+  to {
+    filter: hue-rotate(360deg);
+  }
+}
+
 @layer utilities {
   .animate-gradient {
     animation: gradient-shift 3s ease infinite;
     background-size: 200% 200%;
+  }
+
+  .animated-hue {
+    animation: hue-rotate 10s linear infinite;
   }
 }
 


### PR DESCRIPTION
## Summary
- animate avatar gradient hue and add tilt effect to hero card
- give hero CTA buttons motion on hover
- color-code project cards by category
- map globe colors to theme hues and animate over time
- accent live ticker and tech news feed with theme colors
- add utility classes for tilt and hue rotation

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684158b62e34832294ef5c740494a735