### PR TITLE
Smooth page transitions and stabilize layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,19 +17,23 @@ import SpotlightEffect from '@/components/ui/SpotlightEffect';
 function ScrollToTop() {
   const { pathname } = useLocation();
   useEffect(() => {
-    window.scrollTo(0, 0);
+    // Jump instantly — a smooth scroll here fights the page-enter animation
+    window.scrollTo({ top: 0, behavior: 'instant' as ScrollBehavior });
   }, [pathname]);
   return null;
 }
 
-// Clears the fixed navbar on pages that don't start with a full-screen hero
+// Interior pages clear the fixed navbar and fill the viewport so the footer
+// stays pinned to the bottom instead of floating up on short pages.
 function Page({ children }: { children: React.ReactNode }) {
-  return <div className="pt-16">{children}</div>;
+  return (
+    <div className="flex flex-col pt-16 min-h-[calc(100vh-4rem)]">{children}</div>
+  );
 }
 
 function NotFound() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center text-center px-4">
+    <div className="flex flex-1 flex-col items-center justify-center text-center px-4 py-24">
       <p className="kicker mb-4">404</p>
       <h1 className="text-4xl md:text-5xl font-bold tracking-tight">
         Page not found
@@ -47,12 +51,58 @@ function NotFound() {
   );
 }
 
+// Keyed on the path so the incoming page remounts and replays page-enter
+function AnimatedRoutes() {
+  const location = useLocation();
+  return (
+    <div key={location.pathname} className="page-enter flex flex-1 flex-col">
+      <Routes location={location}>
+        <Route path="/" element={<Hero />} />
+        <Route
+          path="/about"
+          element={
+            <Page>
+              <About />
+              <Skills />
+            </Page>
+          }
+        />
+        <Route
+          path="/projects"
+          element={
+            <Page>
+              <Projects />
+            </Page>
+          }
+        />
+        <Route
+          path="/social"
+          element={
+            <Page>
+              <SocialHub />
+            </Page>
+          }
+        />
+        <Route
+          path="/contact"
+          element={
+            <Page>
+              <Contact />
+            </Page>
+          }
+        />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </div>
+  );
+}
+
 function App() {
   return (
     <ThemeProvider defaultTheme="dark" storageKey="portfolio-theme">
       <BrowserRouter>
         <ScrollToTop />
-        <div className="min-h-screen bg-background font-sans antialiased">
+        <div className="flex min-h-screen flex-col bg-background font-sans antialiased">
           <a
             href="#main"
             className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[60] focus:rounded-full focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-black"
@@ -62,44 +112,8 @@ function App() {
           <SpotlightEffect />
           <Navbar />
           <TechNewsFeed />
-          <main id="main" className="relative">
-            <Routes>
-              <Route path="/" element={<Hero />} />
-              <Route
-                path="/about"
-                element={
-                  <Page>
-                    <About />
-                    <Skills />
-                  </Page>
-                }
-              />
-              <Route
-                path="/projects"
-                element={
-                  <Page>
-                    <Projects />
-                  </Page>
-                }
-              />
-              <Route
-                path="/social"
-                element={
-                  <Page>
-                    <SocialHub />
-                  </Page>
-                }
-              />
-              <Route
-                path="/contact"
-                element={
-                  <Page>
-                    <Contact />
-                  </Page>
-                }
-              />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
+          <main id="main" className="relative flex flex-1 flex-col">
+            <AnimatedRoutes />
           </main>
           <Footer />
           <Toaster />

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -352,7 +352,11 @@ export default function Projects() {
             const tabProjects = projects.filter((p) => p.type === tab.value);
             const useGrid = tab.value === 'prop';
             return (
-              <TabsContent key={tab.value} value={tab.value}>
+              <TabsContent
+                key={tab.value}
+                value={tab.value}
+                className="min-h-[600px] focus-visible:outline-none"
+              >
                 {tabProjects.length === 0 ? (
                   <p className="text-center text-muted-foreground py-12">
                     More coming soon.

--- a/src/components/sections/SocialHub.tsx
+++ b/src/components/sections/SocialHub.tsx
@@ -101,6 +101,7 @@ const socialData = {
 export default function SocialHub() {
   const [githubRepos, setGithubRepos] = useState<GitHubRepo[]>([]);
   const [redditPosts, setRedditPosts] = useState<RedditPost[]>([]);
+  const [reposLoading, setReposLoading] = useState(true);
 
   useEffect(() => {
     const fetchRepos = async () => {
@@ -125,6 +126,8 @@ export default function SocialHub() {
         setGithubRepos(repos);
       } catch (err: unknown) {
         console.error('Failed to fetch GitHub repositories:', err);
+      } finally {
+        setReposLoading(false);
       }
     };
 
@@ -190,12 +193,12 @@ export default function SocialHub() {
           </div>
 
           {/* GitHub Tab */}
-          <TabsContent value="github" className="space-y-6">
+          <TabsContent value="github" className="space-y-6 min-h-[420px]">
             <p className="text-center text-muted-foreground mb-6">
               Check out my top repositories on GitHub where I share developer
               tools, automation scripts, and more.
             </p>
-            {githubRepos.length === 0 && (
+            {!reposLoading && githubRepos.length === 0 && (
               <p className="text-center text-sm text-muted-foreground">
                 Couldn't load repositories right now — browse them directly on{' '}
                 <a
@@ -210,6 +213,14 @@ export default function SocialHub() {
               </p>
             )}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              {reposLoading &&
+                githubRepos.length === 0 &&
+                Array.from({ length: 6 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="h-40 rounded-xl border border-white/10 bg-white/[0.02] animate-pulse"
+                  />
+                ))}
               {githubRepos.map((repo) => (
                 <Card key={repo.id} className="spotlight-card card-hover border-white/10 bg-white/[0.02]">
                   <CardHeader className="pb-2">
@@ -250,7 +261,7 @@ export default function SocialHub() {
           </TabsContent>
 
           {/* DeviantArt Tab */}
-          <TabsContent value="deviantArt">
+          <TabsContent value="deviantArt" className="min-h-[420px]">
             <p className="text-center text-muted-foreground mb-6">
               Creative work and UI design concepts on DeviantArt
             </p>
@@ -282,7 +293,7 @@ export default function SocialHub() {
           </TabsContent>
 
           {/* YouTube Tab */}
-          <TabsContent value="youtube">
+          <TabsContent value="youtube" className="min-h-[420px]">
             <p className="text-center text-muted-foreground mb-6">
               Visual effects and creative render showcases on YouTube
             </p>
@@ -326,7 +337,7 @@ export default function SocialHub() {
           </TabsContent>
 
           {/* Reddit Tab */}
-          <TabsContent value="reddit">
+          <TabsContent value="reddit" className="min-h-[420px]">
             <p className="text-center text-muted-foreground mb-6">
               Latest on Reddit
             </p>

--- a/src/index.css
+++ b/src/index.css
@@ -223,11 +223,30 @@
     transform: none;
   }
 
+  /* Route change: fade + gentle rise for the incoming page */
+  .page-enter {
+    animation: page-in 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  @keyframes page-in {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .reveal {
       opacity: 1;
       transform: none;
       transition: none;
+    }
+    .page-enter {
+      animation: none;
     }
   }
 


### PR DESCRIPTION
Fixes the clunky navigation and jumping footer reported after the multi-page conversion.

- **Page transitions** — each route fades and gently rises in (0.45s ease) on navigation, keyed on the path so the incoming page mounts cleanly. Honors prefers-reduced-motion.
- **Instant scroll reset** — navigating now jumps to the top instantly instead of smooth-scrolling and fighting the transition.
- **Sticky footer** — the app shell is a `min-h-screen` flex column with a `flex-1` main and min-height interior pages, so the footer stays pinned to the bottom instead of floating up mid-screen on short pages (e.g. Contact).
- **No more content jump** — Projects and Social tab panels reserve a min-height so switching tabs doesn't yank the layout; the GitHub feed shows skeleton cards while loading instead of popping in and shoving the footer.

Verified with build, lint, tests, and a browser check confirming the footer sits below the fold (not mid-screen) and the transition class is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpGNwuH7DKgt1SC4TSnavr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpGNwuH7DKgt1SC4TSnavr)_