### PR TITLE
Remove availability badge and navbar AC wordmark

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -47,7 +47,6 @@ export default function Navbar() {
             alt="Nexco Media logo"
             className="h-9 w-auto"
           />
-          <span className="hidden sm:inline">AC</span>
         </Link>
 
         {/* Desktop Navigation */}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -70,13 +70,6 @@ export default function Hero() {
               />
             </div>
 
-            <div className="flex justify-center">
-              <span className="inline-flex items-center gap-2.5 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm text-muted-foreground">
-                <span className="pulse-dot" />
-                Available for opportunities
-              </span>
-            </div>
-
             <h1 className="text-6xl md:text-8xl font-extrabold tracking-tight leading-[1.05]">
               Anthony
               <br />


### PR DESCRIPTION
Per request: the hero drops the "Available for opportunities" pill (emblem now leads straight into the name), and the navbar shows the logo alone without the "AC" text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpGNwuH7DKgt1SC4TSnavr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpGNwuH7DKgt1SC4TSnavr)_