### PR TITLE
Prevent stale-cache breakage: HTML must revalidate

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,10 +1,19 @@
 # Cloudflare Pages headers
 
+# HTML shell must always revalidate so it never references dead asset hashes
 /*
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Cache-Control: no-cache
+
+# Unhashed media — short cache, revalidate after
+/images/*
+  Cache-Control: public, max-age=3600
+
+/docs/*
+  Cache-Control: public, max-age=3600
 
 # Hashed build assets never change — cache for a year
 /assets/*


### PR DESCRIPTION
Fixes the "site renders as unstyled raw HTML" failure just reported.

**Root cause:** a browser that loaded the page around a deploy boundary cached an HTML shell referencing asset hashes that no longer exist in the new deployment. The SPA fallback then answered the missing-CSS request with HTML, and the blanket `immutable, max-age=31536000` header on `/assets/*` made the browser keep that poisoned response — so the site stayed permanently unstyled through normal refreshes.

**Fix (`public/_headers`):**
- `/*` (the HTML shell and any non-asset path): `Cache-Control: no-cache` — browsers revalidate the shell on every load, so it always points at live asset hashes
- `/images/*`, `/docs/*` (unhashed media): 1-hour cache
- `/assets/*` (hashed build output): unchanged — a year, immutable

Verified the current prod assets serve correctly; this prevents the recurrence class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpGNwuH7DKgt1SC4TSnavr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpGNwuH7DKgt1SC4TSnavr)_