### PR TITLE
Add GitHub contribution graph and profile stats to Social Hub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
+        "react-github-calendar": "^5.0.6",
         "react-hook-form": "^7.53.0",
         "react-icons": "^5.5.0",
         "react-resizable-panels": "^2.1.3",
@@ -895,20 +896,22 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
-      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.8"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.11.tgz",
-      "integrity": "sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.8"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/react-dom": {
@@ -924,9 +927,10 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@hookform/resolvers": {
       "version": "3.9.0",
@@ -5585,6 +5589,57 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-activity-calendar": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-activity-calendar/-/react-activity-calendar-3.2.0.tgz",
+      "integrity": "sha512-v+ZD61h7RB76YMDh1aGAZuoXsSymSixKMOMusMoYWxhDXkFUX6hiftHin/tWqIS9zSNA/NN+vzYDK4hPF0wuxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.19",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-activity-calendar/node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/react-activity-calendar/node_modules/@floating-ui/react/node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/react-activity-calendar/node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/react-day-picker": {
       "version": "8.10.1",
       "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
@@ -5608,6 +5663,18 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-github-calendar": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/react-github-calendar/-/react-github-calendar-5.0.6.tgz",
+      "integrity": "sha512-BXgk1blzmkXjzc3CJRtSxscNuL0y/pHHVihmY+H+8bak0Syg2G/7gCM4Ja6CzE5wtABDv6N97kKSufWqMazq/g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-activity-calendar": "^3.1.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-hook-form": {
@@ -6165,6 +6232,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
+    "react-github-calendar": "^5.0.6",
     "react-hook-form": "^7.53.0",
     "react-icons": "^5.5.0",
     "react-resizable-panels": "^2.1.3",

--- a/src/components/sections/SocialHub.tsx
+++ b/src/components/sections/SocialHub.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { Github, Youtube, FileCode, Brush } from 'lucide-react';
+import { Github, Youtube, FileCode, Brush, Star, Users, FolderGit2 } from 'lucide-react';
 import { FaTiktok } from 'react-icons/fa';
+import { GitHubCalendar } from 'react-github-calendar';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useEffect, useState } from 'react';
 import Reveal from '@/components/ui/Reveal';
@@ -130,9 +131,18 @@ const socialData = {
   ],
 };
 
+interface GitHubProfileStats {
+  publicRepos: number;
+  followers: number;
+  totalStars: number;
+}
+
 export default function SocialHub() {
   const [githubRepos, setGithubRepos] = useState<GitHubRepo[]>([]);
   const [reposLoading, setReposLoading] = useState(true);
+  const [profileStats, setProfileStats] = useState<GitHubProfileStats | null>(
+    null
+  );
 
   useEffect(() => {
     const fetchRepos = async () => {
@@ -142,6 +152,26 @@ export default function SocialHub() {
         );
         if (!res.ok) return;
         const data: GitHubApiRepo[] = await res.json();
+        const totalStars = data.reduce(
+          (sum, repo) => sum + repo.stargazers_count,
+          0
+        );
+        try {
+          const userRes = await fetch('https://api.github.com/users/ant3869');
+          if (userRes.ok) {
+            const user = (await userRes.json()) as {
+              public_repos: number;
+              followers: number;
+            };
+            setProfileStats({
+              publicRepos: user.public_repos,
+              followers: user.followers,
+              totalStars,
+            });
+          }
+        } catch {
+          // stats row simply doesn't render
+        }
         const repos = data
           .sort((a, b) => b.stargazers_count - a.stargazers_count)
           .slice(0, 6)
@@ -197,6 +227,45 @@ export default function SocialHub() {
               Check out my top repositories on GitHub where I share developer
               tools, automation scripts, and more.
             </p>
+
+            {/* Contribution graph */}
+            <div className="spotlight-card rounded-2xl border border-white/10 bg-white/[0.02] p-6 md:p-7">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
+                <h3 className="font-bold flex items-center">
+                  <Github className="h-5 w-5 mr-2.5 text-primary" />
+                  Contribution Activity
+                </h3>
+                {profileStats && (
+                  <div className="flex flex-wrap gap-2">
+                    <span className="tech-badge inline-flex items-center gap-1.5">
+                      <FolderGit2 className="h-3.5 w-3.5" />
+                      {profileStats.publicRepos} repos
+                    </span>
+                    <span className="tech-badge inline-flex items-center gap-1.5">
+                      <Star className="h-3.5 w-3.5" />
+                      {profileStats.totalStars} stars
+                    </span>
+                    <span className="tech-badge inline-flex items-center gap-1.5">
+                      <Users className="h-3.5 w-3.5" />
+                      {profileStats.followers} followers
+                    </span>
+                  </div>
+                )}
+              </div>
+              <div className="overflow-x-auto pb-1 text-muted-foreground">
+                <GitHubCalendar
+                  username="ant3869"
+                  colorScheme="dark"
+                  theme={{
+                    dark: ['#161b22', '#0e4429', '#006d32', '#26a641', '#39d353'],
+                  }}
+                  blockSize={11}
+                  blockMargin={3}
+                  fontSize={12}
+                  errorMessage="Couldn't load contribution data right now — see the full graph on GitHub."
+                />
+              </div>
+            </div>
             {!reposLoading && githubRepos.length === 0 && (
               <p className="text-center text-sm text-muted-foreground">
                 Couldn't load repositories right now — browse them directly on{' '}


### PR DESCRIPTION
The GitHub tab now leads with a **Contribution Activity** card:

- The classic green-squares contribution calendar (via `react-github-calendar`, which pulls public contribution data — no token needed), themed with GitHub's dark palette, horizontally scrollable on small screens
- Profile stat chips: public repos, total stars (summed across all repos), and followers
- Graceful fallback text when the data can't load

Verified layout and fallback in-browser; the calendar data fetch is confirmed working (API returns 200) and renders client-side in normal browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpGNwuH7DKgt1SC4TSnavr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpGNwuH7DKgt1SC4TSnavr)_