### PR TITLE
Hero centerpiece: orbit rings, aurora background, and sparkles

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -47,27 +47,84 @@ export default function Hero() {
 
   return (
     <section id="home" className="relative min-h-screen overflow-hidden">
-      {/* Subtle radial glow + dot grid behind the headline */}
-      <div
-        className="pointer-events-none absolute inset-0"
-        aria-hidden="true"
-        style={{
-          background:
-            'radial-gradient(ellipse 60% 40% at 50% 40%, rgba(59, 130, 246, 0.08), transparent 70%)',
-        }}
-      />
+      {/* Aurora blobs + dot grid behind the headline */}
+      <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
+        <div
+          className="aurora-blob"
+          style={{
+            top: '8%',
+            left: '18%',
+            width: '34rem',
+            height: '22rem',
+            background: 'radial-gradient(circle, rgba(59,130,246,0.5), transparent 70%)',
+          }}
+        />
+        <div
+          className="aurora-blob"
+          style={{
+            top: '30%',
+            right: '12%',
+            width: '30rem',
+            height: '20rem',
+            background: 'radial-gradient(circle, rgba(168,85,247,0.4), transparent 70%)',
+            animationDelay: '-6s',
+            animationDuration: '22s',
+          }}
+        />
+        <div
+          className="aurora-blob"
+          style={{
+            bottom: '6%',
+            left: '38%',
+            width: '26rem',
+            height: '18rem',
+            background: 'radial-gradient(circle, rgba(244,114,182,0.25), transparent 70%)',
+            animationDelay: '-12s',
+            animationDuration: '26s',
+          }}
+        />
+      </div>
       <div className="dot-grid pointer-events-none absolute inset-0" aria-hidden="true" />
 
       <div className="container mx-auto px-4 relative z-10">
         <div className="min-h-screen flex flex-col items-center justify-center text-center py-28">
           <div className="space-y-6 max-w-4xl">
-            {/* Brand mark as the focal anchor */}
+            {/* Centerpiece: emblem with orbit rings and sparkles */}
             <div className="flex justify-center">
-              <img
-                src="/images/logo-mark.png"
-                alt="Nexco Media"
-                className="h-24 md:h-28 w-auto drop-shadow-[0_0_35px_rgba(96,165,250,0.3)]"
-              />
+              <div className="relative flex h-48 w-48 md:h-60 md:w-60 items-center justify-center">
+                {/* Orbit rings (desktop and up) */}
+                <div className="hidden md:block" aria-hidden="true">
+                  <div className="orbit-ring h-44 w-44" />
+                  <div className="orbit-ring h-60 w-60" />
+                  <div
+                    className="orbit-dot bg-blue-400"
+                    style={{ '--orbit-radius': '88px', '--orbit-duration': '14s' } as React.CSSProperties}
+                  />
+                  <div
+                    className="orbit-dot orbit-reverse bg-purple-400"
+                    style={{ '--orbit-radius': '120px', '--orbit-duration': '22s', '--orbit-start': '140deg' } as React.CSSProperties}
+                  />
+                  <div
+                    className="orbit-dot bg-pink-400"
+                    style={{ '--orbit-radius': '120px', '--orbit-duration': '30s', '--orbit-start': '290deg', height: '6px', width: '6px' } as React.CSSProperties}
+                  />
+                </div>
+
+                {/* Sparkles */}
+                <div aria-hidden="true">
+                  <span className="sparkle" style={{ top: '12%', left: '20%', '--twinkle-delay': '0s' } as React.CSSProperties} />
+                  <span className="sparkle" style={{ top: '30%', right: '8%', '--twinkle-delay': '0.8s' } as React.CSSProperties} />
+                  <span className="sparkle" style={{ bottom: '18%', left: '10%', '--twinkle-delay': '1.6s' } as React.CSSProperties} />
+                  <span className="sparkle" style={{ bottom: '8%', right: '22%', '--twinkle-delay': '2.4s' } as React.CSSProperties} />
+                  <span className="sparkle" style={{ top: '4%', right: '38%', '--twinkle-delay': '3s' } as React.CSSProperties} />
+                </div>
+
+                <img
+                  src="/images/logo-mark.png"
+                  alt="Nexco Media"
+                  className="float-slow relative h-24 md:h-28 w-auto drop-shadow-[0_0_35px_rgba(96,165,250,0.35)]"
+                />
+              </div>
             </div>
 
             <h1 className="text-6xl md:text-8xl font-extrabold tracking-tight leading-[1.05]">

--- a/src/index.css
+++ b/src/index.css
@@ -143,6 +143,108 @@
     }
   }
 
+  /* Aurora: slow-drifting color blobs behind the hero */
+  .aurora-blob {
+    position: absolute;
+    border-radius: 9999px;
+    filter: blur(90px);
+    opacity: 0.35;
+    animation: aurora-drift 18s ease-in-out infinite alternate;
+  }
+
+  @keyframes aurora-drift {
+    from {
+      transform: translate3d(-6%, -4%, 0) scale(1);
+    }
+    to {
+      transform: translate3d(6%, 5%, 0) scale(1.15);
+    }
+  }
+
+  /* Orbit rings around the hero emblem */
+  .orbit-ring {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    border-radius: 9999px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .orbit-dot {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    height: 8px;
+    width: 8px;
+    margin: -4px 0 0 -4px;
+    border-radius: 9999px;
+    animation: orbit var(--orbit-duration, 20s) linear infinite;
+  }
+
+  .orbit-dot::after {
+    content: '';
+    position: absolute;
+    inset: -5px;
+    border-radius: inherit;
+    background: inherit;
+    filter: blur(7px);
+    opacity: 0.8;
+  }
+
+  @keyframes orbit {
+    from {
+      transform: rotate(var(--orbit-start, 0deg)) translateX(var(--orbit-radius));
+    }
+    to {
+      transform: rotate(calc(var(--orbit-start, 0deg) + 360deg))
+        translateX(var(--orbit-radius));
+    }
+  }
+
+  .orbit-reverse {
+    animation-direction: reverse;
+  }
+
+  /* Gentle float for the emblem */
+  .float-slow {
+    animation: float-y 6s ease-in-out infinite;
+  }
+
+  @keyframes float-y {
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(-10px);
+    }
+  }
+
+  /* Twinkling sparkle points */
+  .sparkle {
+    position: absolute;
+    height: 3px;
+    width: 3px;
+    border-radius: 9999px;
+    background: #cbd5e1;
+    opacity: 0;
+    animation: twinkle 3.5s ease-in-out infinite;
+    animation-delay: var(--twinkle-delay, 0s);
+  }
+
+  @keyframes twinkle {
+    0%,
+    100% {
+      opacity: 0;
+      transform: scale(0.6);
+    }
+    50% {
+      opacity: 0.9;
+      transform: scale(1.25);
+    }
+  }
+
   /* Pulsing availability dot */
   .pulse-dot {
     position: relative;
@@ -173,8 +275,15 @@
     .gradient-accent,
     .gradient-border::before,
     .pulse-dot::after,
-    .animate-marquee {
+    .animate-marquee,
+    .aurora-blob,
+    .orbit-dot,
+    .float-slow,
+    .sparkle {
       animation: none;
+    }
+    .sparkle {
+      opacity: 0.5;
     }
   }
 


### PR DESCRIPTION
Visual upgrade in the 21st.dev style, per request for a cool hero centerpiece:

- **Orbiting-circles centerpiece** — the brand emblem floats gently inside two thin orbit rings carrying glowing blue/purple/pink dots at different radii, speeds, and directions (the signature MagicUI/21st.dev pattern)
- **Twinkling sparkles** scattered around the emblem
- **Aurora background** — three large, slow-drifting blurred color blobs (blue/purple/pink) replace the flat radial glow, giving the black hero real depth

Pure CSS, zero new dependencies. All animations disabled under prefers-reduced-motion; orbit rings render from md screens up (mobile keeps the floating emblem + sparkles).

Verified with build, lint, and browser screenshots at two animation moments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpGNwuH7DKgt1SC4TSnavr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpGNwuH7DKgt1SC4TSnavr)_